### PR TITLE
Remove content-length header attribute from MapMessage

### DIFF
--- a/src/CentralDesktop/Stomp/Message/Map.php
+++ b/src/CentralDesktop/Stomp/Message/Map.php
@@ -24,7 +24,7 @@ use CentralDesktop\Stomp;
  *
  * @package Stomp
  */
-class Map extends Stomp\Message\Bytes {
+class Map extends Stomp\Message {
     public $map;
 
     /**


### PR DESCRIPTION
Sending a map message from PHP to a Java based consumer via ActiveMQ failes because of superfluous content-length attribute in header information. ActiveMQ uses content-length attribute to distinguish ByteMessages from other messages (TextMessage or MapMessage) as described in [Stomp implementation on ActiveMQ](http://activemq.apache.org/stomp.html#Stomp-WorkingwithJMSText/BytesMessagesandStomp).
