### PR TITLE
Fix #11: fclose call only with resource handle.

### DIFF
--- a/src/CentralDesktop/Stomp/Connection.php
+++ b/src/CentralDesktop/Stomp/Connection.php
@@ -121,7 +121,7 @@ class Connection implements LoggerAwareInterface {
         while (!$connected && $att++ < $this->_attempts) {
 
             // cleanup any leftover sockets
-            if ($this->_socket !== null) {
+            if (is_resource($this->_socket)) {
                 fclose($this->_socket);
                 $this->_socket = null;
             }


### PR DESCRIPTION
This is an other solution for calling fclose() with only valid resource handle as prosposed by dstevenson in pull request #12. 